### PR TITLE
Upgrade deps

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -4,10 +4,12 @@ const _ = require('lodash');
 const webpack = require('webpack');
 const autoprefixer = require('autoprefixer');
 const HappyPack = require('happypack');
+const TerserPlugin = require("terser-webpack-plugin");
 const moment = require('moment');
 
 const isProduction = () => process.env.NODE_ENV === 'production';
 
+let optimization = {};
 let plugins = [
   new HappyPack({
     id: 'jsx',
@@ -80,10 +82,17 @@ if (isProduction()) {
   plugins = [
     ...plugins,
     new webpack.optimize.ModuleConcatenationPlugin(),
-    new webpack.optimize.UglifyJsPlugin({
-      compressor: { warnings: false, screw_ie8: false },
-    }),
   ];
+  optimization = {
+    minimize: true,
+    minimizer: [
+      new TerserPlugin({
+        terserOptions: {
+          ie8: true
+        }
+      })
+    ],
+  }
 }
 
 const entry = _.reduce(
@@ -109,6 +118,8 @@ module.exports = {
     filename: '[name].js',
     publicPath: '/',
   },
+
+  optimization,
 
   plugins,
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hull-connector",
-  "version": "1.0.46",
+  "version": "1.0.48",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "exit-hook": "^1.1.1",
     "faker": "^4.1.0",
     "glob": "^7.1.6",
-    "happypack": "^4.0.1",
+    "happypack": "^5.0.1",
     "lint-staged": "^6.1.1",
     "lodash": "^4.17.21",
     "lodash-id": "^0.14.0",
@@ -100,11 +100,13 @@
     "shelljs": "^0.8.4",
     "style-loader": "^0.23.1",
     "svg-inline-loader": "^0.8.2",
-    "webpack": "^3.12",
+    "terser-webpack-plugin": "^4.2.3",
+    "webpack": "^4.46.0",
     "webpack-alternate-require-loader": "^0.0.3"
   },
   "devDependencies": {
     "npm-check": "^5.9.2",
-    "rimraf": "^2.7.1"
+    "rimraf": "^2.7.1",
+    "webpack-cli": "^4.9.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hull-connector",
   "description": "Hull Connector Archetype (Uses Builder)",
-  "version": "1.0.47",
+  "version": "1.0.48",
   "main": "dist/index.js",
   "license": "MIT",
   "homepage": "https://hull.io/docs",


### PR DESCRIPTION
Upgrade webpack and replace uglify with terser plugin. New node versions (14+) can't use the uglify-js webpack integrated module. It has to be replaced by the terser-webpack-plugin.